### PR TITLE
Add k3s_ci.yml as a github workflow for testing in k3s

### DIFF
--- a/.github/workflows/k3s_ci.yml
+++ b/.github/workflows/k3s_ci.yml
@@ -1,0 +1,136 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
+
+name: k3s llama-api-server CI
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  k3s-demo:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-wasip1
+          cache: false
+
+      - name: Install WasmEdge with WASI-NN plugin
+        run: |
+          curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- --plugins wasi_nn-ggml -v 0.14.1
+          
+      - name: Build and install Runwasi's containerd-shim-wasmedge-v1
+        run: |
+          cd $HOME
+          git clone https://github.com/containerd/runwasi.git
+          cd runwasi
+          ./scripts/setup-linux.sh
+          make build-wasmedge
+          INSTALL="sudo install" LN="sudo ln -sf" make install-wasmedge
+          source ~/.bashrc
+          which containerd-shim-wasmedge-v1 # verify installation
+
+      - name: Install k3s
+        run: |
+          cd $HOME
+          curl -sfL https://get.k3s.io | sh -
+          sudo chmod 777 /etc/rancher/k3s/k3s.yaml # hack
+
+      - name: Build LlamaEdge's llama-api-server.wasm
+        run: |
+          cd $GITHUB_WORKSPACE
+
+          sed -i -e '/define CHECK_CONTAINERD_VERSION/,/^endef/{
+          s/Containerd version must be/WARNING: Containerd version should be/
+          /exit 1;/d
+          }' Makefile
+
+          git -C apps/llamaedge apply $PWD/disable_wasi_logging.patch
+
+          OPT_PROFILE=release RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" make apps/llamaedge/llama-api-server
+
+      - name: Build the llama-api-server.wasm's OCI image and import it to k3s' containerd
+        run: |
+          cd apps/llamaedge/llama-api-server
+          oci-tar-builder --name llama-api-server \
+            --repo ghcr.io/second-state \
+            --tag latest \
+            --module target/wasm32-wasip1/release/llama-api-server.wasm \
+            -o target/wasm32-wasip1/release/img-oci.tar
+          sudo k3s ctr image import --all-platforms target/wasm32-wasip1/release/img-oci.tar
+
+          sudo k3s ctr images ls # verify image import
+
+      - name: Download gguf model
+        run: |
+          sudo mkdir -p $HOME/models
+          sudo chmod 777 $HOME/models
+          cd /home/runner/models
+          curl -LO https://huggingface.co/second-state/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q5_K_M.gguf
+
+      - name: Create and apply Kubernetes deployment
+        run: |
+          sudo k3s kubectl apply -f $GITHUB_WORKSPACE/k3s/k3s_deployment.yaml
+          sleep 20
+          sudo k3s kubectl get pods
+          
+      - name: Port-forward from k3s in background
+        run: |
+          sudo k3s kubectl port-forward svc/llama-api-server-service 8080:8080 > /dev/null 2>&1 &
+          PF_PID=$!
+          echo "Port-forward PID: $PF_PID"
+          echo "PORTER_PID=$PF_PID" >> $GITHUB_ENV
+          sleep 6
+      
+      - name: Test API endpoint and log the output
+        run: |
+          mkdir -p logs
+          curl -X POST http://localhost:8080/v1/chat/completions \
+            -H 'accept:application/json' \
+            -H 'Content-Type: application/json' \
+            -d '{
+                "messages": [
+                    {"role": "system", "content": "You are a helpful assistant."},
+                    {"role": "user", "content": "Who is Robert Oppenheimer?"}
+                ],
+                "model": "llama-3-1b"
+            }' | tee "logs/api_response_$(date +'%Y-%m-%d').json"
+      
+      - name: Display and save pod logs
+        run: |
+          POD_NAME=$(sudo k3s kubectl get pods -l app=llama-api-server --no-headers -o custom-columns=":metadata.name" | head -n 1)
+          echo "POD_NAME=$POD_NAME" >> $GITHUB_ENV
+          sudo k3s kubectl logs $POD_NAME
+          sudo k3s kubectl logs $POD_NAME > "logs/pod_logs_$(date +'%Y-%m-%d').log"
+          
+      - name: Upload Logs as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: daily-logs-${{ github.run_number }}
+          path: logs/
+
+      - name: Cleanup
+        if: always()
+        run: |
+          echo "Cleaning up resources..."
+          # Kill port-forward if it exists
+          if [ -n "${{ env.PORTER_PID }}" ]; then
+            sudo kill ${{ env.PORTER_PID }} 2>/dev/null || true
+          fi
+          # Delete kubernetes resources
+          sudo k3s kubectl delete -f $GITHUB_WORKSPACE/k3s_deployment.yaml 2>/dev/null || true
+          # Show final status
+          sudo k3s kubectl get pods -l app=llama-api-server || true

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > For now, only llama-api-server has been added as a plugin demo. In the future, some basic tests will be included as part of regular CI testing.
 
+> For `Runwasi with WasmEdge runtime demo in k3s`, refer [./k3s/k3s.README.md](https://github.com/second-state/runwasi-wasmedge-demo/k3s/k3s.README.md)
+
 1. Manually removed the dependency on wasi_logging due to issue [#4003](https://github.com/WasmEdge/WasmEdge/issues/4003).
 
 ```bash

--- a/k3s/k3s.README.md
+++ b/k3s/k3s.README.md
@@ -1,0 +1,150 @@
+# Running `github.com/second-state/runwasi-wasmedge-demo` in k3s
+
+### 1. Installing dependencies 
+```sh
+# apt installable
+sudo apt update && sudo apt upgrade -y && sudo apt install -y llvm-14-dev liblld-14-dev software-properties-common gcc g++ asciinema containerd cmake zlib1g-dev build-essential python3 python3-dev python3-pip git clang
+
+# Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source $HOME/.cargo/env
+rustup target add wasm32-wasip1
+exec $SHELL
+
+# WasmEdge + WASINN plugin
+curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- --plugins wasi_nn-ggml -v 0.14.1 # binaries and plugin in $HOME/.wasmedge
+source $HOME/.bashrc
+
+# Runwasi's containerd-shim-wasmedge-v1
+cd
+git clone https://github.com/containerd/runwasi.git
+cd runwasi
+./scripts/setup-linux.sh
+make build-wasmedge
+INSTALL="sudo install" LN="sudo ln -sf" make install-wasmedge
+which containerd-shim-wasmedge-v1 # verify
+
+# deps - k3s installation
+cd
+curl -sfL https://get.k3s.io | sh - 
+sudo chmod 777 /etc/rancher/k3s/k3s.yaml # hack
+```
+
+### 2. Configuring containerd to use containerd-shim-wasmedge-v1
+k3s' containerd supports wasmedge and crun as runtimes, so when we restart k3s using 
+
+`sudo systemctl restart k3s`
+
+it finds those binaries in `/usr/local/bin` automatically and automatically writes a config.toml to `/var/lib/rancher/k3s/agent/etc/containerd/config.toml` reflecting that it now has the ability to successfully utilize those
+```sh
+sudo systemctl restart k3s
+```
+
+
+### 3. Building image ghcr.io/second-state/llama-api-server:latest
+This step builds the `ghcr.io/second-state/llama-api-server:latest` image and imports it to the k3s' containerd's local image store
+
+> same as `Build and import demo image` from [README.md]](https://github.com/second-state/runwasi-wasmedge-demo/README.md)
+
+```sh
+# build llama-server-wasm
+cd
+
+git clone --recurse-submodules https://github.com/second-state/runwasi-wasmedge-demo.git
+
+cd runwasi-wasmedge-demo
+
+# edit makefile to eliminate containerd version error
+sed -i -e '/define CHECK_CONTAINERD_VERSION/,/^endef/{
+s/Containerd version must be/WARNING: Containerd version should be/
+/exit 1;/d
+}' Makefile
+
+# Manually removed the dependency on wasi_logging due to issue #4003.
+git -C apps/llamaedge apply $PWD/disable_wasi_logging.patch
+
+OPT_PROFILE=release RUSTFLAGS="--cfg wasmedge --cfg tokio_unstable" make apps/llamaedge/llama-api-server
+
+# place llama-server-img in k3s' containerd local store
+cd $HOME/runwasi-wasmedge-demo/apps/llamaedge/llama-api-server
+oci-tar-builder --name llama-api-server \
+    --repo ghcr.io/second-state \
+    --tag latest \
+    --module target/wasm32-wasip1/release/llama-api-server.wasm \
+    -o target/wasm32-wasip1/release/img-oci.tar # Create OCI image from the WASM binary
+sudo k3s ctr image import --all-platforms $HOME/runwasi-wasmedge-demo/apps/llamaedge/llama-api-server/target/wasm32-wasip1/release/img-oci.tar 
+sudo k3s ctr images ls # verify the import
+```
+
+### 4. Download the gguf model needed by llama-api-server
+```sh 
+cd
+sudo mkdir -p models
+sudo chmod 777 models  # ensure it's readable by k3s
+cd models
+curl -LO https://huggingface.co/second-state/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q5_K_M.gguf
+```
+
+### 5. Create the kubernetes configuration yaml ( ref [k3s_deployment.yaml](https://github.com/second-state/runwasi-wasmedge-demo/k3s/k3s_deployment.yaml) )
+This config is for Ubuntu:25.05 running on x84_64 platform, so paths for system libs might be different.
+For example, on Ubuntu 22.04 running on ARM64 platform, the paths for system libs will look like :
+
+`/lib/aarch64-linux-gnu/libm.so.6`
+`/lib/aarch64-linux-gnu/libpthread.so.0`
+`/lib/aarch64-linux-gnu/libc.so.6`
+`/lib/ld-linux-aarch64.so.1`
+`/lib/aarch64-linux-gnu/libdl.so.2`
+`/lib/aarch64-linux-gnu/libstdc++.so.6`
+`/lib/aarch64-linux-gnu/libgcc-s.so.1`
+
+So, for a different platform, all libs in output of 
+`~/.wasmedge/plugin/libwasmedgePluginWasiNN.so`
+should be mounted as files to exact same paths at which they were in host machine
+
+```sh
+sudo k3s kubectl apply -f k3s/k3s_deployment.yaml
+
+#verify
+sudo k3s kubectl get pods
+sudo k3s kubectl describe pod llama-api-***-***
+```
+
+### 5. Query the llama-api-server
+```sh
+# In terminal 1:
+sudo k3s kubectl port-forward svc/llama-api-server-service 8080:8080
+# o/p:
+# Forwarding from 127.0.0.1:8080 -> 8080
+# Forwarding from [::1]:8080 -> 8080
+# Handling connection for 8080
+
+# In terminal 2:
+curl -X POST http://localhost:8080/v1/chat/completions \
+    -H 'accept:application/json' \
+    -H 'Content-Type: application/json' \
+    -d '{
+        "messages": [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Who is Robert Oppenheimer?"}
+        ],
+        "model": "llama-3-1b"
+    }'
+# o/p :
+# {"id":"chatcmpl-10af011c-a33b-4d36-9dad-b136253e204d","object":"chat.completion","created":1752085233,"model":"llama-3-1b","choices":[{"index":0,"message":{"content":"Robert Oppenheimer (1904-1967) was an American theoretical physicist who played a key role in the development of the atomic bomb during World War II. He is widely regarded as one of the most influential scientists of the 20th century.\n\nOppenheimer was born on April 22, 1904, in New York City to Jewish parents from Russia. His early life was marked by his family's emigration to the United States after anti-Semitic violence against Jews in Germany. He received his Ph.D. in physics from Princeton University in 1927 and worked at various research institutions, including the University of California, Berkeley.\n\nIn 1933, Oppenheimer joined Los Alamos Laboratory (now Los Alamos National Laboratory) as a young physicist working on a top-secret project to develop an atomic bomb under J. Robert Oppenheimer's direction. This project was code-named \"Manhattan Project.\" In 1942, the United States dropped the first atomic bombs on Hiroshima and Nagasaki, Japan, leading to his involvement in the development of the atomic bomb.\n\nAfter the war, Oppenheimer continued his work at Los Alamos and later became the director of the Manhattan Project's secret research division. He also played a key role in shaping the post-war nuclear policy, particularly through his presidency of the Advisory Committee on Nuclear Energy (ACNE), which helped to establish the United States' nuclear energy industry.\n\nDespite his crucial contributions to the development of atomic energy and national security, Oppenheimer was haunted by the moral implications of his work. He believed that his involvement in the Manhattan Project had made him complicit in the bombings, and he struggled with personal demons throughout his life. In 1954, he was subjected to a series of \"security clearance examinations\" due to allegations of subversive activities, which damaged his reputation and led to his eventual expulsion from government service.\n\nOppenheimer's views on science were also criticized for being too nuanced and scientifically skeptical. He believed that scientists should be guided by principles of ethics rather than simply pursuing power. After his retirement in 1955, he became an advocate for disarmament and arms control.\n\nThe 1986 book \"American Prometheus: The Triumph and Tragedy of J. Robert Oppenheimer\" was a critical biography written by Kai Bird and Martin J. Sherwin that helped to redeem Oppenheimer's reputation and provide a nuanced understanding of his complex legacy.\n\nDespite the controversy surrounding him, Robert Oppenheimer remains an important figure in science history and continues to be celebrated for his contributions to physics and his role in shaping our understanding of atomic energy.","role":"assistant"},"finish_reason":"stop","logprobs":null}],"usage":{"prompt_tokens":28,"completion_tokens":534,"total_tokens":562}}
+```
+```sh
+sudo k3s kubectl logs llama-api-server-d87d7b4dd-z24xv
+# o/p:
+# [2025-07-09 18:09:09.781] [info] [WASI-NN] GGML backend: LLAMA_COMMIT 2e89f76b
+# [2025-07-09 18:09:09.781] [info] [WASI-NN] GGML backend: LLAMA_BUILD_NUMBER 5640
+# .
+# .
+# .
+# [2025-07-09 18:20:33.566] [info] [WASI-NN] llama.cpp: llama_perf_context_print:        eval time =       0.00 ms /   533 runs   (    0.00 ms per token,      inf tokens per second)
+# [2025-07-09 18:20:33.566] [info] [WASI-NN] llama.cpp: llama_perf_context_print:       total time =  683783.35 ms /   561 tokens
+```
+
+### 6. Cleanup
+```sh
+cd
+sudo k3s kubectl delete -f deployment.yaml
+```

--- a/k3s/k3s_deployment.yaml
+++ b/k3s/k3s_deployment.yaml
@@ -1,0 +1,127 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llama-api-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: llama-api-server
+  template:
+    metadata:
+      labels:
+        app: llama-api-server
+    spec:
+      runtimeClassName: wasmedge
+      containers:
+        - name: llama-api-server
+          image: ghcr.io/second-state/llama-api-server:latest
+          imagePullPolicy: Never
+          command: ["llama-api-server.wasm"]
+          args:
+            - "--prompt-template"
+            - "llama-3-chat"
+            - "--ctx-size"
+            - "4096"
+            - "--model-name"
+            - "llama-3-1b"
+          env:
+            - name: WASMEDGE_PLUGIN_PATH
+              value: "/home/runner/.wasmedge/plugin"
+            - name: LD_LIBRARY_PATH
+              value: "/home/runner/.wasmedge/lib"
+            - name: WASMEDGE_WASINN_PRELOAD
+              value: "default:GGML:CPU:/home/runner/models/Llama-3.2-1B-Instruct-Q5_K_M.gguf"
+          volumeMounts:
+            - name: gguf-model-file
+              mountPath: /home/runner/models/Llama-3.2-1B-Instruct-Q5_K_M.gguf
+              readOnly: true
+            - name: wasi-nn-plugin-file
+              mountPath: /home/runner/.wasmedge/plugin/libwasmedgePluginWasiNN.so
+              readOnly: true
+            - name: wasi-nn-plugin-lib
+              mountPath: /home/runner/.wasmedge/lib
+              readOnly: true
+            - name: libm
+              mountPath: /lib/x86_64-linux-gnu/libm.so.6
+              readOnly: true
+            - name: libpthread
+              mountPath: /lib/x86_64-linux-gnu/libpthread.so.0
+              readOnly: true
+            - name: libc
+              mountPath: /lib/x86_64-linux-gnu/libc.so.6
+              readOnly: true
+            - name: ld-linux
+              mountPath: /lib64/ld-linux-x86-64.so.2
+              readOnly: true
+            - name: libdl
+              mountPath: /lib/x86_64-linux-gnu/libdl.so.2
+              readOnly: true
+            - name: libstdcxx
+              mountPath: /lib/x86_64-linux-gnu/libstdc++.so.6
+              readOnly: true
+            - name: libgcc-s
+              mountPath: /lib/x86_64-linux-gnu/libgcc_s.so.1
+              readOnly: true
+      volumes:
+        - name: gguf-model-file
+          hostPath:
+            path: /home/runner/models/Llama-3.2-1B-Instruct-Q5_K_M.gguf
+            type: File
+        - name: wasi-nn-plugin-file
+          hostPath:
+            path: /home/runner/.wasmedge/plugin/libwasmedgePluginWasiNN.so
+            type: File
+        - name: wasi-nn-plugin-lib
+          hostPath:
+            path: /home/runner/.wasmedge/lib
+            type: Directory
+        - name: libm
+          hostPath:
+            path: /lib/x86_64-linux-gnu/libm.so.6
+            type: File
+        - name: libpthread
+          hostPath:
+            path: /lib/x86_64-linux-gnu/libpthread.so.0
+            type: File
+        - name: libc
+          hostPath:
+            path: /lib/x86_64-linux-gnu/libc.so.6
+            type: File
+        - name: ld-linux
+          hostPath:
+            path: /lib64/ld-linux-x86-64.so.2
+            type: File
+        - name: libdl
+          hostPath:
+            path: /lib/x86_64-linux-gnu/libdl.so.2
+            type: File
+        - name: libstdcxx
+          hostPath:
+            path: /lib/x86_64-linux-gnu/libstdc++.so.6
+            type: File
+        - name: libgcc-s
+          hostPath:
+            path: /lib/x86_64-linux-gnu/libgcc_s.so.1
+            type: File
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llama-api-server-service
+spec:
+  selector:
+    app: llama-api-server
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: wasmedge
+handler: wasmedge


### PR DESCRIPTION
This PR adds a GitHub Actions workflow `k3s_ci.yml` that can run daily 
  - to test the behavior of WASI-NN plugin in k3s
      - Successful Run : [https://github.com/vatsalkeshav/runwasi-wasmedge-demo/actions/runs/16244179734/job/45864596613](https://github.com/vatsalkeshav/runwasi-wasmedge-demo/actions/runs/16244179734/job/45864596613)
  - while demonstrating the usage of llamaedge's `llama-api-server` in k3s

Documentation supporting above workflow is also added
  - `k3s.README.md`