### PR TITLE
Add k3s/k3s.helm.README.md : Supporting helm usage for repetetive mounts generation in yaml

### DIFF
--- a/k3s/k3s.README.md
+++ b/k3s/k3s.README.md
@@ -1,5 +1,7 @@
 # Running `github.com/second-state/runwasi-wasmedge-demo` in k3s
 
+> For `generating custom k3s_deployment_op.yaml template with wasi-nn plugin and dependencies volume mounts for different linux based OS'es`, refer [./k3s/k3s.README.md)(https://github.com/second-state/runwasi-wasmedge-demo/k3s/k3s.helm.README.md)
+
 ### 1. Installing dependencies 
 ```sh
 # apt installable
@@ -98,7 +100,14 @@ For example, on Ubuntu 22.04 running on ARM64 platform, the paths for system lib
 
 So, for a different platform, all libs in output of 
 `~/.wasmedge/plugin/libwasmedgePluginWasiNN.so`
-should be mounted as files to exact same paths at which they were in host machine
+should be mounted as files to exact same paths at which they were in host machine.
+
+> For this purpose, `k3s/wasi-nn-chart/values-generator.sh` is here
+( NOTE : the `valued-generator.sh` leverages `ldd` and `wasmedge -v` )
+
+> Again, for `generating custom k3s_deployment_op.yaml template with wasi-nn plugin and dependencies volume mounts for different linux based OS'es`, refer [./k3s/k3s.README.md)(https://github.com/second-state/runwasi-wasmedge-demo/k3s/k3s.helm.README.md)
+
+After following the steps from `k3s.helm.README.md`, you the generated `k3s_deployment_op.yaml` can be used for the linux based OS on which it was generated
 
 ```sh
 sudo k3s kubectl apply -f k3s/k3s_deployment.yaml

--- a/k3s/k3s.helm.README.md
+++ b/k3s/k3s.helm.README.md
@@ -1,0 +1,70 @@
+# Generating custom k3s_deployment_op.yaml template with wasi-nn plugin and dependencies volume mounts for different linux based OS'es using `helm`
+
+### 1. Install helm 
+```sh
+curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+```
+
+### 2. Generate helm chart (or use the wasi-nn-chart provided)
+```sh
+helm create wasi-nn-chart
+
+# the provided wasi-nn-chart has the unnecessary stuff removed so as to keep the output yaml clean
+cd k3s/wasi-nn-chart
+```
+
+### 2. values-generator.sh usage
+
+#### Why is this needed?
+The yaml config for Ubuntu 22.04 running on ARM64 platform and Ubuntu 22.04 running on x86_64 platform is different due to the paths for system libs (like)
+```
+`/lib/aarch64-linux-gnu/libm.so.6`
+`/lib/aarch64-linux-gnu/libpthread.so.0`
+`/lib/aarch64-linux-gnu/libc.so.6`
+`/lib/ld-linux-aarch64.so.1`
+`/lib/aarch64-linux-gnu/libdl.so.2`
+`/lib/aarch64-linux-gnu/libstdc++.so.6`
+`/lib/aarch64-linux-gnu/libgcc-s.so.1`
+```
+
+So, for a different platform, all libs in output of 
+`~/.wasmedge/plugin/libwasmedgePluginWasiNN.so`
+should be mounted as files to exact same paths at which they were in host machine.
+
+For this purpose, `values-generator.sh` is here
+
+```sh
+chmod +x values_generator.sh
+./values_generator.sh # creates ./values.yaml
+```
+
+NOTE :
+This script leverages 
+
+1. `wasmedge -v`
+    ```sh
+    wasmedge -v
+    # o/p :
+    # wasmedge version 0.14.1
+    #  (plugin "wasi_logging") version 0.1.0.0
+    # /home/dev/.wasmedge/lib/../plugin/libwasmedgePluginWasiNN.so (plugin "wasi_nn") version 0.1.28.0
+    ```
+    to know the path of `.wasmedge/` directory which comprises of the  `wasi-nn plugin` itself and most of the necessary libs(`.so`s) it needs
+    So, make sure to install `wasmedge` and `wasi-nn plugin` using
+    ```sh
+    curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- --plugins wasi_nn-ggml -v 0.14.1
+    ```
+    or other suitable method.
+    otherwise the output of `wasmedge -v` might not contain this part :
+    ```sh
+    /home/dev/.wasmedge/lib/../plugin/libwasmedgePluginWasiNN.so (plugin "wasi_nn") version 0.1.28.0
+    ```
+2. `ldd`
+
+    use of `ldd` command to know the dependencies of `libwasmedgePluginWasiNN.so`
+
+### 2. generate final k3s_deployment_op.yaml using helm
+```sh
+# (exemplar) : this was run on ubuntu:22.04 on ARM64 platform
+helm template wasi-nn ./ -f values.yaml > k3s_deployment_op.yaml
+```

--- a/k3s/k3s_deployment_op.yaml
+++ b/k3s/k3s_deployment_op.yaml
@@ -1,0 +1,127 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llama-api-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: llama-api-server
+  template:
+    metadata:
+      labels:
+        app: llama-api-server
+    spec:
+      runtimeClassName: wasmedge
+      containers:
+        - name: llama-api-server
+          image: ghcr.io/second-state/llama-api-server:latest
+          imagePullPolicy: Never
+          command: ["llama-api-server.wasm"]
+          args:
+            - "--prompt-template"
+            - "llama-3-chat"
+            - "--ctx-size"
+            - "4096"
+            - "--model-name"
+            - "llama-3-1b"
+          env:
+            - name: WASMEDGE_PLUGIN_PATH
+              value: "/home/runner/.wasmedge/plugin"
+            - name: LD_LIBRARY_PATH
+              value: "/home/runner/.wasmedge/lib"
+            - name: WASMEDGE_WASINN_PRELOAD
+              value: "default:GGML:CPU:/home/runner/models/Llama-3.2-1B-Instruct-Q5_K_M.gguf"
+          volumeMounts:
+            - name: gguf-model-file
+              mountPath: /home/runner/models/Llama-3.2-1B-Instruct-Q5_K_M.gguf
+              readOnly: true
+            - name: wasi-nn-plugin-file
+              mountPath: /home/runner/.wasmedge/plugin/libwasmedgePluginWasiNN.so
+              readOnly: true
+            - name: wasi-nn-plugin-lib
+              mountPath: /home/runner/.wasmedge/lib
+              readOnly: true
+            - name: libm
+              mountPath: /lib/x86_64-linux-gnu/libm.so.6
+              readOnly: true
+            - name: libpthread
+              mountPath: /lib/x86_64-linux-gnu/libpthread.so.0
+              readOnly: true
+            - name: libc
+              mountPath: /lib/x86_64-linux-gnu/libc.so.6
+              readOnly: true
+            - name: ld-linux
+              mountPath: /lib64/ld-linux-x86-64.so.2
+              readOnly: true
+            - name: libdl
+              mountPath: /lib/x86_64-linux-gnu/libdl.so.2
+              readOnly: true
+            - name: libstdcxx
+              mountPath: /lib/x86_64-linux-gnu/libstdc++.so.6
+              readOnly: true
+            - name: libgcc-s
+              mountPath: /lib/x86_64-linux-gnu/libgcc_s.so.1
+              readOnly: true
+      volumes:
+        - name: gguf-model-file
+          hostPath:
+            path: /home/runner/models/Llama-3.2-1B-Instruct-Q5_K_M.gguf
+            type: File
+        - name: wasi-nn-plugin-file
+          hostPath:
+            path: /home/runner/.wasmedge/plugin/libwasmedgePluginWasiNN.so
+            type: File
+        - name: wasi-nn-plugin-lib
+          hostPath:
+            path: /home/runner/.wasmedge/lib
+            type: Directory
+        - name: libm
+          hostPath:
+            path: /lib/x86_64-linux-gnu/libm.so.6
+            type: File
+        - name: libpthread
+          hostPath:
+            path: /lib/x86_64-linux-gnu/libpthread.so.0
+            type: File
+        - name: libc
+          hostPath:
+            path: /lib/x86_64-linux-gnu/libc.so.6
+            type: File
+        - name: ld-linux
+          hostPath:
+            path: /lib64/ld-linux-x86-64.so.2
+            type: File
+        - name: libdl
+          hostPath:
+            path: /lib/x86_64-linux-gnu/libdl.so.2
+            type: File
+        - name: libstdcxx
+          hostPath:
+            path: /lib/x86_64-linux-gnu/libstdc++.so.6
+            type: File
+        - name: libgcc-s
+          hostPath:
+            path: /lib/x86_64-linux-gnu/libgcc_s.so.1
+            type: File
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llama-api-server-service
+spec:
+  selector:
+    app: llama-api-server
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: wasmedge
+handler: wasmedge

--- a/k3s/wasi-nn-chart/Chart.yaml
+++ b/k3s/wasi-nn-chart/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: wasi-nn-chart
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/k3s/wasi-nn-chart/templates/k3s_deployment.yaml
+++ b/k3s/wasi-nn-chart/templates/k3s_deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llama-api-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: llama-api-server
+  template:
+    metadata:
+      labels:
+        app: llama-api-server
+    spec:
+      runtimeClassName: wasmedge
+      containers:
+        - name: llama-api-server
+          image: ghcr.io/second-state/llama-api-server:latest
+          imagePullPolicy: Never
+          command: ["llama-api-server.wasm"]
+          args:
+            - "--prompt-template"
+            - "llama-3-chat"
+            - "--ctx-size"
+            - "4096"
+            - "--model-name"
+            - "llama-3-1b"
+          env:
+            - name: WASMEDGE_PLUGIN_PATH
+              value: "{{ .Values.paths.wasi_nn_plugin_file_dir }}"
+            - name: LD_LIBRARY_PATH
+              value: "{{ .Values.paths.wasi_nn_plugin_lib_dir }}"
+            - name: WASMEDGE_WASINN_PRELOAD
+              value: "default:GGML:CPU:/home/runner/models/Llama-3.2-1B-Instruct-Q5_K_M.gguf"
+          volumeMounts:
+            - name: gguf-model-file
+              mountPath: /home/runner/models/Llama-3.2-1B-Instruct-Q5_K_M.gguf
+              readOnly: true
+            - name: wasi-nn-plugin-file
+              mountPath: {{ .Values.paths.wasi_nn_plugin_file }}
+              readOnly: true
+            - name: wasi-nn-plugin-lib-dir
+              mountPath: {{ .Values.paths.wasi_nn_plugin_lib_dir }}
+              readOnly: true
+{{- range .Values.systemLibs }}
+            - name: {{ .name }}
+              mountPath: {{ .hostPath }}
+              readOnly: true
+{{- end }}
+      volumes:
+        - name: gguf-model-file
+          hostPath:
+            path: /home/runner/models/Llama-3.2-1B-Instruct-Q5_K_M.gguf
+            type: File
+        - name: wasi-nn-plugin-file
+          hostPath:
+            path: {{ .Values.paths.wasi_nn_plugin_file }}
+            type: File
+        - name: wasi-nn-plugin-lib-dir
+          hostPath:
+            path: {{ .Values.paths.wasi_nn_plugin_lib_dir }}
+            type: Directory
+{{- range .Values.systemLibs }}
+        - name: {{ .name }}
+          hostPath:
+            path: {{ .hostPath }}
+            type: File
+{{- end }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llama-api-server-service
+spec:
+  selector:
+    app: llama-api-server
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: wasmedge
+handler: wasmedge

--- a/k3s/wasi-nn-chart/values-generator.sh
+++ b/k3s/wasi-nn-chart/values-generator.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# find plugin file dynamically from `wasmedge -v`
+PLUGIN_FILE_RAW=$(wasmedge -v 2>&1 | grep "libwasmedgePluginWasiNN.so" | awk '{print $1}')
+PLUGIN_FILE=$(realpath "$PLUGIN_FILE_RAW")
+
+PLUGIN_DIR=$(dirname "$PLUGIN_FILE")
+LIB_DIR=$(realpath "$PLUGIN_DIR/../lib")
+
+cat > values.yaml <<EOF
+# path values to be used by helm
+paths:
+  wasi_nn_plugin_lib_dir: "$LIB_DIR"
+  wasi_nn_plugin_file_dir: "$PLUGIN_DIR"
+  wasi_nn_plugin_file: "$PLUGIN_FILE"
+  
+# systemLibs values to be used by helm
+systemLibs:
+EOF
+
+# collect system libs with ldd
+libs=$(ldd "$PLUGIN_FILE" | awk '
+  $2 == "=>" && $3 ~ /^\// {print $3}
+  $1 ~ /^\// {print $1}
+')
+
+for lib in $libs; do
+  name=$(basename "$lib" | tr '.-' '_')
+  echo "  - name: $name" >> values.yaml
+  echo "    hostPath: $lib" >> values.yaml
+done
+
+echo "values.yaml generated ($(echo "$libs" | wc -l) system libs)"

--- a/k3s/wasi-nn-chart/values.yaml
+++ b/k3s/wasi-nn-chart/values.yaml
@@ -1,0 +1,22 @@
+# path values to be used by helm
+paths:
+  wasi_nn_plugin_lib_dir: "/home/dev/.wasmedge/lib"
+  wasi_nn_plugin_file_dir: "/home/dev/.wasmedge/plugin"
+  wasi_nn_plugin_file: "/home/dev/.wasmedge/plugin/libwasmedgePluginWasiNN.so"
+  
+# systemLibs values to be used by helm
+systemLibs:
+  - name: libm_so_6
+    hostPath: /lib/aarch64-linux-gnu/libm.so.6
+  - name: libpthread_so_0
+    hostPath: /lib/aarch64-linux-gnu/libpthread.so.0
+  - name: libc_so_6
+    hostPath: /lib/aarch64-linux-gnu/libc.so.6
+  - name: ld_linux_aarch64_so_1
+    hostPath: /lib/ld-linux-aarch64.so.1
+  - name: libdl_so_2
+    hostPath: /lib/aarch64-linux-gnu/libdl.so.2
+  - name: libstdc++_so_6
+    hostPath: /lib/aarch64-linux-gnu/libstdc++.so.6
+  - name: libgcc_s_so_1
+    hostPath: /lib/aarch64-linux-gnu/libgcc_s.so.1


### PR DESCRIPTION
This PR adds documentation supporting Helm usage to automate the generation of custom `k3s_deployment_op.yaml` templates for deploying the llama API server with the wasi-nn plugin and its required system library mounts - to ensure compatibility across different Linux platforms - 

**Doc addition:**

* Added a new `k3s.helm.README.md` with step-by-step instructions for generating deployment YAMLs using Helm, including the rationale for system library mounts and usage of the `values-generator.sh` script.

**Supporting script:**

* Introduced the `values-generator.sh` script to automatically detect the wasi-nn plugin path and its shared library dependencies using `wasmedge -v` and `ldd`, and output a corresponding `values.yaml` for Helm.

**Helm chart:**

* Added a Helm chart (`wasi-nn-chart`) with a parameterized deployment template (`templates/k3s_deployment.yaml`) that uses values from `values.yaml` to mount the correct plugin and system libraries for the target OS/architecture. 

**Example output:**

* Added a sample generated `k3s_deployment_op.yaml` to illustrate the resulting deployment configuration.